### PR TITLE
Fix edge artifacts caused when drawing border after drawing rounded rectangle and ovals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.31'
 
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-alpha02'
+        classpath 'com.android.tools.build:gradle:3.5.0-beta04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.1"
     }

--- a/library/src/main/java/com/kennyc/textdrawable/TextDrawable.kt
+++ b/library/src/main/java/com/kennyc/textdrawable/TextDrawable.kt
@@ -64,7 +64,7 @@ class TextDrawable(
 
     private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG)
 
-    private val borderPaint = Paint()
+    private val innerPaint = Paint()
 
     init {
         // text paint settings
@@ -76,13 +76,17 @@ class TextDrawable(
             textPaint.strokeWidth = borderThickness
         }
 
-        // border paint settings
-        borderPaint.color = getColorForBorder()
-        borderPaint.style = Paint.Style.STROKE
-        borderPaint.strokeWidth = borderThickness
+        if (borderThickness > 0F) {
+            // draw shape as color of border
+            // then fill shape inset by border with the normal color
+            paint.color = getColorForBorder()
+            innerPaint.style = Paint.Style.FILL
+            innerPaint.strokeWidth = borderThickness
+            innerPaint.color = color
+        } else {
+            paint.color = color
+        }
 
-        // drawable paint color
-        paint.color = color
     }
 
     override fun onDraw(shape: Shape, canvas: Canvas, paint: Paint) {
@@ -93,7 +97,7 @@ class TextDrawable(
 
         // draw border
         if (borderThickness > 0F) {
-            drawBorder(canvas)
+            drawInnerShape(canvas)
         }
 
         val count = canvas.save()
@@ -152,17 +156,20 @@ class TextDrawable(
         return bitmap
     }
 
-    private fun drawBorder(canvas: Canvas) {
+    private fun drawInnerShape(canvas: Canvas) {
         val rect = RectF(bounds)
-        val inset = borderThickness / 2f
+        val inset = borderThickness
         rect.inset(inset, inset)
 
         when (shape) {
-            DRAWABLE_SHAPE_ROUND_RECT -> canvas.drawRoundRect(rect, cornerRadius, cornerRadius, borderPaint)
+            DRAWABLE_SHAPE_ROUND_RECT -> {
+                val roundRectCornerRadius = cornerRadius - inset
+                canvas.drawRoundRect(rect, roundRectCornerRadius, roundRectCornerRadius, innerPaint)
+            }
 
-            DRAWABLE_SHAPE_OVAL -> canvas.drawOval(rect, borderPaint)
+            DRAWABLE_SHAPE_OVAL -> canvas.drawOval(rect, innerPaint)
 
-            else -> canvas.drawRect(rect, borderPaint)
+            else -> canvas.drawRect(rect, innerPaint)
         }
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "com.kennyc.sample"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/sample_kotlin/build.gradle
+++ b/sample_kotlin/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
 
     defaultConfig {
         applicationId "com.kennyc.open.sample_kotlin"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Edge artifact pixels of the shape color are created when drawing a border of a rounded rectangle. I saw you were calculating the corner radius of the border incorrectly. How you were drawing the border with a stroke, the corner radius of rounded rectangles should have been  = cornerRadius - (borderThickness/2f), whereas you just used cornerRadius

But, even then I still got some artifacts on the corners I am guessing due to rounding issues.

Below your branch: 
<img width="160" alt="Screen Shot 2019-06-14 at 1 56 30 PM" src="https://user-images.githubusercontent.com/4157455/59538315-27851e80-8eae-11e9-9ecb-5f9da35f0543.png">

I fixed the issue by drawing the shape in the color of the border then filling the shape inset by the stroke width, with the color the shape should be.
<img width="151" alt="Screen Shot 2019-06-14 at 1 52 05 PM" src="https://user-images.githubusercontent.com/4157455/59538316-27851e80-8eae-11e9-979f-02265218bd3b.png">


also I updated the android sdk, kotlin, and gradle
